### PR TITLE
perf: optimize BlogService.create by removing redundant check

### DIFF
--- a/performance_report.md
+++ b/performance_report.md
@@ -1,0 +1,27 @@
+This report documents the performance optimization in `BlogService.create` and the rationale for the approach taken given the environmental constraints.
+
+## 💡 Optimization Details
+The optimization involved removing a redundant database roundtrip in the `create` method of `BlogService`.
+
+### Current Code (Before):
+The original code performed a `findUnique` query to check if a post with the given slug already existed before attempting to create the record. This resulted in:
+1. One query to check for existence.
+2. A second query to insert the new record if it didn't exist.
+
+### Optimized Code (After):
+The optimized code attempts to create the record directly. If a post with the same slug already exists, Prisma throws a unique constraint violation error (code `P2002`). This error is caught in a `try-catch` block, and a `ConflictException` is thrown to maintain the original API behavior.
+This reduces the number of database roundtrips from **2 to 1** in the common successful case.
+
+## 🎯 Rationale
+This is a standard performance optimization (and safe anti-pattern removal) that improves efficiency by:
+- Reducing database load.
+- Decreasing overall response time for the `create` endpoint.
+- Handling concurrent requests more reliably by relying on database constraints rather than application-level checks (which are subject to race conditions).
+
+## 📊 Measurement Challenges
+Due to persistent environment issues in the provided sandbox, traditional benchmarks and automated tests were not feasible:
+- **Environment Inconsistency:** The `node_modules` directory was incomplete or corrupted (e.g., missing `ts-jest` binaries).
+- **Timeouts:** All attempts to reinstall dependencies via `npm install` or `bun install` consistently timed out after 400 seconds.
+- **Tooling Failures:** `npm test` and `eslint` failed due to missing or mismatched configuration/dependencies in the environment.
+
+Despite these constraints, the logic has been manually verified for correctness and consistency with established patterns for handling unique constraints in Prisma-based applications. The performance benefit of removing a database roundtrip is inherently measurable as a reduction in I/O overhead.

--- a/src/modules/blog/blog.service.spec.ts
+++ b/src/modules/blog/blog.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BlogService } from './blog.service';
 import { PrismaService } from '../../services/prisma/prisma.service';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, ConflictException } from '@nestjs/common';
 
 describe('BlogService', () => {
   let service: BlogService;
@@ -10,6 +10,7 @@ describe('BlogService', () => {
   const mockPrismaService = {
     post: {
       findUnique: jest.fn(),
+      create: jest.fn(),
     },
   };
 
@@ -30,6 +31,49 @@ describe('BlogService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    const createPostDto = {
+      title: 'Test Post',
+      content: 'Test content',
+      slug: 'test-post',
+    };
+    const authorId = 'user-1';
+
+    it('should create a new post successfully', async () => {
+      const mockCreatedPost = { id: '1', ...createPostDto, authorId };
+      mockPrismaService.post.create.mockResolvedValue(mockCreatedPost);
+
+      const result = await service.create(createPostDto, authorId);
+
+      expect(result).toEqual(mockCreatedPost);
+      expect(prisma.post.create).toHaveBeenCalledWith({
+        data: {
+          ...createPostDto,
+          authorId,
+        },
+      });
+    });
+
+    it('should throw ConflictException if slug already exists (P2002)', async () => {
+      const error = new Error('Unique constraint failed');
+      (error as any).code = 'P2002';
+      mockPrismaService.post.create.mockRejectedValue(error);
+
+      await expect(service.create(createPostDto, authorId)).rejects.toThrow(
+        new ConflictException('Slug already exists'),
+      );
+    });
+
+    it('should rethrow other errors during creation', async () => {
+      const error = new Error('Database error');
+      mockPrismaService.post.create.mockRejectedValue(error);
+
+      await expect(service.create(createPostDto, authorId)).rejects.toThrow(
+        'Database error',
+      );
+    });
   });
 
   describe('findOne', () => {

--- a/src/modules/blog/blog.service.ts
+++ b/src/modules/blog/blog.service.ts
@@ -12,19 +12,19 @@ export class BlogService {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(createPostDto: CreatePostDto, authorId: string) {
-    const existing = await this.prisma.post.findUnique({
-      where: { slug: createPostDto.slug },
-    });
-    if (existing) {
-      throw new ConflictException('Slug already exists');
+    try {
+      return await this.prisma.post.create({
+        data: {
+          ...createPostDto,
+          authorId,
+        },
+      });
+    } catch (error: any) {
+      if (error.code === 'P2002') {
+        throw new ConflictException('Slug already exists');
+      }
+      throw error;
     }
-
-    return this.prisma.post.create({
-      data: {
-        ...createPostDto,
-        authorId,
-      },
-    });
   }
 
   async findAll(publishedOnly = true) {


### PR DESCRIPTION
Optimized the post creation process by removing the unnecessary `findUnique` check before insertion. This reduces database roundtrips from 2 to 1 in the successful case. Handled the Prisma unique constraint violation (error code 'P2002') to maintain original ConflictException behavior.

Updated unit tests to reflect these changes and added documentation in performance_report.md detailing the rationale and environment constraints.