### PR TITLE
fix: update insecure password validation regex in DTOs

### DIFF
--- a/src/modules/auth/dto/register-user.dto.ts
+++ b/src/modules/auth/dto/register-user.dto.ts
@@ -18,7 +18,7 @@ export class RegisterUserDto {
   @ApiProperty()
   @MinLength(4)
   @MaxLength(20)
-  @Matches(/.*/, {
+  @Matches(/^((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {
     message: 'password is too weak',
   })
   password: string;

--- a/src/modules/auth/dto/reset-password.dto.ts
+++ b/src/modules/auth/dto/reset-password.dto.ts
@@ -9,7 +9,7 @@ export class ResetPasswordDto {
   @IsString()
   @MinLength(4)
   @MaxLength(20)
-  @Matches(/.*/, {
+  @Matches(/^((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/, {
     message: 'senha muito fraca',
   })
   @ApiProperty()


### PR DESCRIPTION
Updated the password validation regex in `RegisterUserDto` and `ResetPasswordDto` to enforce password complexity. The new regex requires at least one uppercase letter, one lowercase letter, and either one digit or one special character. Added start anchor `^` to the regex to ensure proper evaluation of lookaheads.