### PR TITLE
perf: optimize UserService.update by removing redundant findUnique query

### DIFF
--- a/performance_report.md
+++ b/performance_report.md
@@ -25,3 +25,15 @@ Due to persistent environment issues in the provided sandbox, traditional benchm
 - **Tooling Failures:** `npm test` and `eslint` failed due to missing or mismatched configuration/dependencies in the environment.
 
 Despite these constraints, the logic has been manually verified for correctness and consistency with established patterns for handling unique constraints in Prisma-based applications. The performance benefit of removing a database roundtrip is inherently measurable as a reduction in I/O overhead.
+
+---
+
+### Update: Performance Optimization in `UserService.update`
+
+In addition to the `BlogService` optimization, a similar improvement was applied to `UserService.update`.
+
+#### 💡 Optimization Details
+The redundant `findOneUser(id)` call was removed. Originally, the code queried the database to check for existence before performing the update.
+
+#### 🎯 Rationale
+Prisma's `update` operation already throws a `P2025` error if the record is not found. By catching this error and throwing a `NotFoundException`, we achieve the same behavior with **one less database roundtrip**, improving the response time and efficiency of user updates.

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -57,7 +57,9 @@ describe('UserController', () => {
 
   describe('listResellers', () => {
     it('should list all resellers', async () => {
-      const expectedResult = [{ id: '1', username: 'reseller1', role: Role.RESELLER }];
+      const expectedResult = [
+        { id: '1', username: 'reseller1', role: Role.RESELLER },
+      ];
       mockUserService.findAll.mockResolvedValue(expectedResult);
 
       const result = await controller.listResellers();

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -75,9 +75,6 @@ export class UserService {
   }
 
   async update(id: string, updateUserDto: UpdateUserDto) {
-    const user = await this.findOneUser(id);
-    if (!user) throw new NotFoundException('User not found');
-
     const { email, username, password } = updateUserDto;
     const data: any = {};
 
@@ -87,16 +84,23 @@ export class UserService {
       data.password = await bcrypt.hash(password, 10);
     }
 
-    const updatedUser = await this.prisma.user.update({
-      where: { id },
-      data: {
-        ...data,
-        tokenVersion: { increment: 1 },
-      },
-    });
+    try {
+      const updatedUser = await this.prisma.user.update({
+        where: { id },
+        data: {
+          ...data,
+          tokenVersion: { increment: 1 },
+        },
+      });
 
-    const { password: _, ...result } = updatedUser;
-    return result;
+      const { password: _, ...result } = updatedUser;
+      return result;
+    } catch (error) {
+      if (error.code === 'P2025') {
+        throw new NotFoundException('User not found');
+      }
+      throw error;
+    }
   }
 
   async remove(id: string) {


### PR DESCRIPTION
- Removed unnecessary findOneUser(id) call before update
- Added try-catch block to handle Prisma P2025 error and throw NotFoundException
- Updated performance_report.md with optimization rationale
- Verified changes manually due to environment-related test timeouts