### PR TITLE
🔒 [security] Restrict CORS policy for missing Origin header

### DIFF
--- a/src/modules/cors/cors.service.spec.ts
+++ b/src/modules/cors/cors.service.spec.ts
@@ -38,9 +38,9 @@ describe('CorsService', () => {
   });
 
   describe('isOriginAllowed', () => {
-    it('should return true if origin is undefined', async () => {
+    it('should return false if origin is undefined', async () => {
       const result = await service.isOriginAllowed(undefined);
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     it('should return true for default allowed origins', async () => {

--- a/src/modules/cors/cors.service.ts
+++ b/src/modules/cors/cors.service.ts
@@ -44,7 +44,7 @@ export class CorsService implements OnModuleInit {
   }
 
   async isOriginAllowed(origin: string | undefined): Promise<boolean> {
-    if (!origin) return true; // Allow non-browser requests (e.g. Postman)
+    if (!origin) return false; // Block non-browser requests or requests without origin header
     return this.allowedOrigins.has(origin);
   }
 }


### PR DESCRIPTION
- Update CorsService to reject requests where the Origin header is missing or undefined.
- Update unit tests to reflect the new strict policy.