### PR TITLE
refactor: use instanceof PrismaClientKnownRequestError for error hand…

### DIFF
--- a/src/modules/blog/blog.service.ts
+++ b/src/modules/blog/blog.service.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../services/prisma/prisma.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
@@ -20,7 +21,10 @@ export class BlogService {
         },
       });
     } catch (error: any) {
-      if (error.code === 'P2002') {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
         throw new ConflictException('Slug already exists');
       }
       throw error;

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../services/prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -96,7 +97,10 @@ export class UserService {
       const { password: _, ...result } = updatedUser;
       return result;
     } catch (error) {
-      if (error.code === 'P2025') {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
         throw new NotFoundException('User not found');
       }
       throw error;
@@ -112,7 +116,10 @@ export class UserService {
       const { password: _, ...result } = deletedUser;
       return result;
     } catch (error) {
-      if (error.code === 'P2025') {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
         throw new NotFoundException('User not found');
       }
       throw error;


### PR DESCRIPTION
…ling

Standardized error handling in UserService and BlogService by using `instanceof Prisma.PrismaClientKnownRequestError` before checking the error code. This improves type safety and maintainability.