### PR TITLE
🔒 security fix: Remove hardcoded JWT secret fallbacks

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -338,10 +338,15 @@ export class AuthService {
       expiresIn: jwtExpiration,
     } as any);
 
+    const refreshTokenSecret = this.configService.get<string>(
+      'REFRESH_TOKEN_SECRET',
+    );
+    if (!refreshTokenSecret) {
+      throw new Error('REFRESH_TOKEN_SECRET environment variable is not defined');
+    }
+
     const refreshToken = await this.jwtService.signAsync(payload, {
-      secret:
-        this.configService.get<string>('REFRESH_TOKEN_SECRET') ||
-        'refresh-secret-key-change-me',
+      secret: refreshTokenSecret,
       expiresIn: jwtRefreshExpiration,
     } as any);
 

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,3 +1,7 @@
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not defined');
+}
+
 export const jwtConstants = {
-  secret: process.env.JWT_SECRET || 'DO_NOT_USE_THIS_VALUE_IN_PRODUCTION',
+  secret: process.env.JWT_SECRET,
 };

--- a/src/auth/refresh-token.strategy.ts
+++ b/src/auth/refresh-token.strategy.ts
@@ -9,14 +9,18 @@ export class RefreshTokenStrategy extends PassportStrategy(
   'jwt-refresh',
 ) {
   constructor() {
+    const secret = process.env.REFRESH_TOKEN_SECRET;
+    if (!secret) {
+      throw new Error('REFRESH_TOKEN_SECRET environment variable is not defined');
+    }
+
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request) => {
           return request?.cookies?.refresh_token;
         },
       ]),
-      secretOrKey:
-        process.env.REFRESH_TOKEN_SECRET || 'refresh-secret-key-change-me',
+      secretOrKey: secret,
       passReqToCallback: true,
     });
   }


### PR DESCRIPTION
This commit removes insecure hardcoded fallback values for JWT_SECRET and REFRESH_TOKEN_SECRET. The application will now throw an error if these environment variables are not defined, ensuring it never runs in an insecure state.

Affected files:
- src/auth/constants.ts
- src/auth/refresh-token.strategy.ts
- src/auth/auth.service.ts