### PR TITLE
security: remove hardcoded secrets and enforce configuration requirem…

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,19 +3,25 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from '../users/users.module';
 import { JwtModule } from '@nestjs/jwt';
-import { jwtConstants } from './constants';
 import { JwtStrategy } from './jwt.strategy';
 import { RefreshTokenStrategy } from './refresh-token.strategy';
 import { SessionsModule } from './sessions/sessions.module';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
     UsersModule,
     SessionsModule,
-    JwtModule.register({
+    JwtModule.registerAsync({
       global: true,
-      secret: jwtConstants.secret,
-      signOptions: { expiresIn: (process.env.JWT_EXPIRATION || '3d') as any },
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.getOrThrow<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: (configService.get<string>('JWT_EXPIRATION') || '3d') as any,
+        },
+      }),
+      inject: [ConfigService],
     }),
   ],
   providers: [AuthService, JwtStrategy, RefreshTokenStrategy],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -339,9 +339,7 @@ export class AuthService {
     } as any);
 
     const refreshToken = await this.jwtService.signAsync(payload, {
-      secret:
-        this.configService.get<string>('REFRESH_TOKEN_SECRET') ||
-        'refresh-secret-key-change-me',
+      secret: this.configService.getOrThrow<string>('REFRESH_TOKEN_SECRET'),
       expiresIn: jwtRefreshExpiration,
     } as any);
 

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,3 +1,0 @@
-export const jwtConstants = {
-  secret: process.env.JWT_SECRET || 'DO_NOT_USE_THIS_VALUE_IN_PRODUCTION',
-};

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,12 +1,12 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
-import { jwtConstants } from './constants';
+import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private configService: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request) => {
@@ -25,7 +25,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         },
       ]),
       ignoreExpiration: false,
-      secretOrKey: jwtConstants.secret,
+      secretOrKey: configService.getOrThrow<string>('JWT_SECRET'),
     });
   }
 

--- a/src/auth/refresh-token.strategy.ts
+++ b/src/auth/refresh-token.strategy.ts
@@ -2,21 +2,21 @@ import { Injectable, ForbiddenException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { Request } from 'express';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class RefreshTokenStrategy extends PassportStrategy(
   Strategy,
   'jwt-refresh',
 ) {
-  constructor() {
+  constructor(private configService: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request) => {
           return request?.cookies?.refresh_token;
         },
       ]),
-      secretOrKey:
-        process.env.REFRESH_TOKEN_SECRET || 'refresh-secret-key-change-me',
+      secretOrKey: configService.getOrThrow<string>('REFRESH_TOKEN_SECRET'),
       passReqToCallback: true,
     });
   }

--- a/test/security-config.spec.ts
+++ b/test/security-config.spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from '../src/auth/auth.service';
+import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../src/users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { SessionsService } from '../src/auth/sessions/sessions.service';
+
+describe('Security Configuration', () => {
+  let authService: AuthService;
+  let configService: ConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: ConfigService,
+          useValue: {
+            getOrThrow: jest.fn((key: string) => {
+              if (key === 'REFRESH_TOKEN_SECRET') {
+                throw new Error('Configuration property "REFRESH_TOKEN_SECRET" is not defined');
+              }
+              return 'mock-value';
+            }),
+            get: jest.fn().mockReturnValue('mock-value'),
+          },
+        },
+        {
+          provide: UsersService,
+          useValue: {},
+        },
+        {
+          provide: JwtService,
+          useValue: {},
+        },
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
+        {
+          provide: SessionsService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    authService = module.get<AuthService>(AuthService);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  it('should throw an error if REFRESH_TOKEN_SECRET is missing in getTokens', async () => {
+    const user = { id: '1', email: 'test@example.com', userType: 'USER' };
+
+    // We expect getTokens to call configService.getOrThrow('REFRESH_TOKEN_SECRET')
+    // which we mocked to throw an error.
+    await expect(authService.getTokens('1', 'test@example.com', user))
+      .rejects.toThrow('Configuration property "REFRESH_TOKEN_SECRET" is not defined');
+  });
+});


### PR DESCRIPTION
…ents

- Replaced hardcoded fallback secrets with `ConfigService.getOrThrow` in `AuthService`.
- Refactored `AuthModule` to use `JwtModule.registerAsync` for stricter secret enforcement.
- Updated `JwtStrategy` and `RefreshTokenStrategy` to use `ConfigService.getOrThrow`.
- Removed insecure `src/auth/constants.ts` file.
- Added security configuration validation test in `test/security-config.spec.ts`.